### PR TITLE
add root requirements.txt for unified project

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,51 @@
+# =============================================================================
+# LexoRead - Core Requirements
+# =============================================================================
+# Core dependencies for running the LexoRead application (API + Models).
+#
+# For component-specific optional dependencies, see:
+#   - datasets/requirements.txt          (dataset downloading & preprocessing)
+#   - models/emotion_tts/requirements.txt (emotion-aware TTS extras)
+#   - models/summarization_requirements.txt (LLM-based text summarization)
+# =============================================================================
+
+# --- Web Framework & API ---
+fastapi>=0.100.0
+uvicorn>=0.22.0
+pydantic>=1.10.0,<2.0.0          # config.py uses pydantic v1 BaseSettings API
+python-multipart>=0.0.6
+aiofiles>=23.1.0
+
+# --- Authentication & Security ---
+python-jose[cryptography]>=3.3.0
+passlib[bcrypt]>=1.7.4
+
+# --- Database ---
+sqlalchemy>=2.0.18
+alembic>=1.11.1
+
+# --- Configuration ---
+python-dotenv>=1.0.0
+
+# --- Machine Learning Core ---
+torch>=2.0.1
+torchvision>=0.15.0
+transformers>=4.30.0
+numpy>=1.21.0
+scipy>=1.7.0
+scikit-learn>=1.3.0
+
+# --- NLP & Text Processing ---
+nltk>=3.8.1
+
+# --- Audio Processing ---
+librosa>=0.9.0
+soundfile>=0.10.0
+
+# --- Image Processing & OCR ---
+Pillow>=10.0.0
+opencv-python>=4.8.0
+
+# --- Utilities ---
+requests>=2.25.0
+tqdm>=4.61.0


### PR DESCRIPTION
## Summary
  - README references `pip install -r requirements.txt` at the project root, but this file was missing
  - Dependencies were scattered across `api/services/pyproject.toml`, `datasets/requirements.txt`, `models/emotion_tts/requirements.txt`, and
  `models/summarization_requirements.txt`
  - Consolidates core dependencies (API, ML, NLP, audio, image processing) into a single root file
  - Pins pydantic<2.0 because `api/config.py` uses the v1 BaseSettings API
  - Component-specific extras remain in their respective subdirectories

  ## Test plan
  - [x] `pip install -r requirements.txt` completes without conflicts
  - [x] Existing sub-requirements still work independently