### PR TITLE
add .gitignore for Python, Node.js, ML models and IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,81 @@
+# =============================================================================
+# LexoRead .gitignore
+# =============================================================================
+
+# --- Python ---
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+*.egg-info/
+*.egg
+dist/
+build/
+eggs/
+*.whl
+
+# --- Virtual Environments ---
+venv/
+.venv/
+env/
+ENV/
+
+# --- Environment & Secrets ---
+.env
+.env.local
+.env.production
+# Keep .env.example tracked
+!.env.example
+
+# --- IDE & Editors ---
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.project
+.settings/
+
+# --- OS Files ---
+.DS_Store
+Thumbs.db
+Desktop.ini
+
+# --- ML Model Artifacts ---
+*.pt
+*.pth
+*.bin
+*.h5
+*.onnx
+*.safetensors
+models/pretrained/
+models/checkpoints/
+
+# --- Database ---
+*.db
+*.sqlite3
+
+# --- Logs ---
+*.log
+logs/
+
+# --- Node.js (frontend) ---
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.next/
+
+# --- Jupyter Notebooks ---
+.ipynb_checkpoints/
+
+# --- Testing & Coverage ---
+.coverage
+htmlcov/
+.pytest_cache/
+.mypy_cache/
+
+# --- Datasets (large files) ---
+datasets/raw/
+datasets/processed/
+datasets/downloads/


### PR DESCRIPTION
## Summary
  - Project had no .gitignore since migration from private to public repository
  - Covers Python bytecode, virtual environments, IDE files, OS files
  - Ignores ML model artifacts (.pt, .pth, .bin, .h5, .onnx) to prevent large binary commits
  - Ignores .env files while keeping .env.example tracked
  - Ignores SQLite database files referenced in api/config.py
  - Includes rules for planned Node.js frontend and Jupyter notebooks
  - Ignores downloaded/processed dataset directories

  ## Test plan
  - [x] Verify .env.example is still tracked (`git ls-files .env.example`)
  - [x] Confirm no existing tracked files are affected